### PR TITLE
feat: print error stack if error type if goerrors.Error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/matrixorigin/controller-runtime
 go 1.19
 
 require (
+	github.com/go-errors/errors v1.5.1
 	github.com/go-logr/logr v1.2.4
 	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJ
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
+github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	recon "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	goerrors "github.com/go-errors/errors"
 	"github.com/go-logr/logr"
 	"github.com/matrixorigin/controller-runtime/pkg/util"
 	"github.com/pkg/errors"
@@ -309,6 +310,12 @@ func (r *Reconciler[T]) processActorError(ctx *Context[T], actorErr error) (reco
 		ctx.Log.V(Debug).Info("update conflict in reconcile, requeue", "detail", actorErr.Error())
 		return requeue, nil
 	}
+
+	// 4. print error stack if using error package "github.com/go-errors/errors"
+	if stackErr, ok := actorErr.(*goerrors.Error); ok {
+		ctx.Log.Error(actorErr, stackErr.ErrorStack())
+	}
+
 	// other errors
 	ctx.Event.EmitEventGeneric(reconcileFail, "failed calling actions", actorErr)
 	return none, errors.Wrap(actorErr, "error calling actions")


### PR DESCRIPTION
fix: https://github.com/matrixorigin/MO-Cloud/issues/1729

将 errors package `github.com/pkg/errors` 替换为 `github.com/go-errors/errors`，原因有：
1. `pkg/errors` 在调用 `errors.Warp` 时，每一次调用都会将当前的 stack 记录到 error 内部，多次调用会产生多个 stack，在打印错误 stack 时，信息冗余。`go-errors/errors` 在方法内部会判断是否已经记录了 stack，不会产生冗余 stack。
2. `pkg/errors` 已经被 archived，不会再更新。
3.  打印错误 stack 时， `go-errors/errors` 会自动换行，而不是仅仅显示换行符`\n`，（如原 issue 中显示的 stack 是 `pkg/errors`的，未换行）

controller-runtime 的 log.Error(err, "msg") 会打印 `pkg/errors` 的 error stack，不打印 `go-errors/errors` 的 error stack，后者需要我们自己调用 `err.ErrorStack()` 或者 `err.Stack()` 方法